### PR TITLE
Long-awaited fix for NetworkX upgrade from v1 to v2, still for QGIS v2.x

### DIFF
--- a/disconnected_islands.py
+++ b/disconnected_islands.py
@@ -30,8 +30,8 @@ import os.path
 
 
 #import networkx as nx
-from PyQt4.QtCore import *
-from qgis.core import * #QgsMapLayerRegistry, QgsVectorDataProvider, QgsField
+from PyQt4.QtCore import Qt
+from qgis.core import QgsMapLayerRegistry, QgsVectorDataProvider, QgsField, QgsSymbolV2, QgsRendererCategoryV2, QgsCategorizedSymbolRendererV2
 from qgis.gui import QgsMessageBar
 from PyQt4.QtGui import QProgressBar, QColor
 from PyQt4 import QtGui
@@ -315,9 +315,9 @@ class DisconnectedIslands:
                 # gather edges and components to which they belong
                 fid_comp = {}
                 for i, graph in enumerate(connected_components):
-                   for edge in graph.edges_iter(data=True):
+                   for edge in graph.edges(data=True):
                        fid_comp[edge[2].get('fid', None)] = i
-
+                
                 # write output to csv file
                 #with open('C:/Tmp/Components.csv', 'wb') as f:
                 #    w = csv.DictWriter(f, fieldnames=['fid', 'group'])

--- a/metadata.txt
+++ b/metadata.txt
@@ -11,7 +11,7 @@
 name=Disconnected Islands
 qgisMinimumVersion=2.0
 description=Finds disconnected "islands" in a transport network layer, so that a routing tool will work between all nodes. A tolerance field allows for imperfect topology.
-version=1.0.3
+version=1.0.4
 author=Peter Smythe @ AfriGIS
 email=peters@afrigis.co.za
 
@@ -29,7 +29,9 @@ repository=https://github.com/AfriGIS-South-Africa/disconnected-islands.git
 # Recommended items:
 
 # Uncomment the following line and add your changelog:
-changelog=Version 1.0.3 (2016-04-11)
+changelog=Version 1.0.4 (2018-11-23)
+    - Fix for NetworkX upgrade from v1 to v2<br/>
+    Version 1.0.3 (2016-04-11)
     - handle error for ESRI Shapefile if attribute name is larger than 10 characters
     - add general exception handling
     - compress sample data into a single ZIP file for easy direct download from GitHub<br/>


### PR DESCRIPTION
First implement long-awaited fix for QGIS v2.x users