### PR TITLE
Fix a bug related to nx.connected_component_subgraphs

### DIFF
--- a/disconnected_islands.py
+++ b/disconnected_islands.py
@@ -314,7 +314,7 @@ class DisconnectedIslands(object):
                 
                 self.iface.messageBar().pushMessage("Finding connected subgraphs, please wait...",  level=Qgis.Warning)     # WARNING - to highlight the next stage, where we cannot show progress
                 QApplication.processEvents()
-                connected_components = list(nx.connected_component_subgraphs(G))    # this takes a long time.  TODO: how to show progress?
+                connected_components = list(G.subgraph(c) for c in nx.connected_components(G)) # this takes a long time.  TODO: how to show progress?
                 self.iface.messageBar().pushMessage("Updating group attribute...",  level=Qgis.Info)
                 QApplication.processEvents()
                           


### PR DESCRIPTION
connected_component_subgraphs has been deprecated in networkx 2.4. See [this notice](https://networkx.github.io/documentation/stable/release/release_2.4.html). This fixes the issue